### PR TITLE
Usage of external ala-i18n resources

### DIFF
--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -4,7 +4,11 @@ import au.org.ala.collectory.ExtendedPluginAwareResourceBundleMessageSource
 beans = {
     // Custom message source
     messageSource(ExtendedPluginAwareResourceBundleMessageSource) {
-        basenames = ["WEB-INF/grails-app/i18n/messages"] as String[]
+        basenames = [
+                "file:///var/opt/atlas/i18n/collectory-plugin/messages",
+                "file:///opt/atlas/i18n/collectory-plugin/messages",
+                "WEB-INF/grails-app/i18n/messages"
+        ] as String[]
         cacheSeconds = (60 * 60 * 6) // 6 hours
         useCodeAsDefaultMessage = false
     }


### PR DESCRIPTION
Use of external resources packaged by:
https://github.com/living-atlases/ala-i18n

Tested with and without the ala-i18n package and with custom local changes.

cc @nickdos @djtfmartin 